### PR TITLE
updated to compile on linux; fixed memory leak

### DIFF
--- a/tests/geos_lineunion/geos_lineunion.pro
+++ b/tests/geos_lineunion/geos_lineunion.pro
@@ -17,4 +17,26 @@ LIBS += \
 	-lvtkIOCore-6.1 \
 	-lvtkIOLegacy-6.1
 
+unix {
+        LIBS += \
+        -lvtkCommonExecutionModel-6.1 \
+        -lvtkCommonMath-6.1 \
+        -lvtkCommonMisc-6.1 \
+        -lvtkCommonSystem-6.1 \
+        -lvtkCommonTransforms-6.1 \
+        -lvtksys-6.1 \
+        -lvtkzlib-6.1
+}
+
 SOURCES += main.cpp
+
+QMAKE_CLEAN += \
+        test1_input.vtk \
+        test1_output.csv \
+        test1_output.vtk \
+        test2_input.vtk \
+        test2_output.csv \
+        test2_output.vtk \
+        test3_input.vtk \
+        test3_output.csv \
+        test3_output.vtk

--- a/tests/geos_lineunion/main.cpp
+++ b/tests/geos_lineunion/main.cpp
@@ -122,7 +122,7 @@ QVector<QVector<QPointF> > unionLines(const QVector<QVector<QPointF> >& lines)
 		auto str = dynamic_cast<const geos::geom::LineString*>(strs->getGeometryN(i));
 		QVector<QPointF> line;
 		for (int j = 0; j < str->getNumPoints(); ++j) {
-			geos::geom::Point* p = str->getPointN(j);
+			std::unique_ptr<geos::geom::Point> p(str->getPointN(j));
 			line.push_back(QPointF(p->getX(), p->getY()));
 		}
 		ret.push_back(line);


### PR DESCRIPTION
Hi Keisuke,

Now that I have iricdev compiling on Linux I was able to run valgrind on iricGeosLineUnion
and found a small memory leak.

Scott