### PR TITLE
added ok button to list of widgets to be enabled/disabled

### DIFF
--- a/libs/guicore/project/inputcond/private/inputconditionwidgetfunctionaldialog.cpp
+++ b/libs/guicore/project/inputcond/private/inputconditionwidgetfunctionaldialog.cpp
@@ -555,6 +555,7 @@ void InputConditionWidgetFunctionalDialog::toggleReadOnly(bool readonly)
 	widgets.push_back(ui->addButton);
 	widgets.push_back(ui->importButton);
 	widgets.push_back(ui->clearButton);
+	widgets.push_back(ui->buttonBox->button(QDialogButtonBox::Ok));
 
 	for (QWidget* w : widgets) {
 		w->setDisabled(readonly);


### PR DESCRIPTION
Hi Keisuke,

Just added the OK button from InputConditionWidgetFunctionalDialog to list of widgets to be enabled/disabled when read-only to be consistent with InputConditionDialog and avoid "Modifications you made will be discarded." message when OK was pressed.

Thanks,
Scott