### PR TITLE
Issue 696

### DIFF
--- a/libs/solverconsole/solverconsolewindow.cpp
+++ b/libs/solverconsole/solverconsolewindow.cpp
@@ -40,6 +40,7 @@ void SolverConsoleWindow::Impl::init()
 {
 	m_window->setMinimumSize(480, 360);
 	m_projectData = nullptr;
+	m_projectDataItem = nullptr;
 	m_destructing = false;
 
 	m_window->exportLogAction = new QAction(SolverConsoleWindow::tr("&Export solver console log..."), m_window);
@@ -300,7 +301,9 @@ void SolverConsoleWindow::clear()
 
 void SolverConsoleWindow::applyPreferenceSetting()
 {
-	impl->m_projectDataItem->loadExternalData();
+	if (impl->m_projectDataItem) {
+		impl->m_projectDataItem->loadExternalData();
+	}
 }
 
 void SolverConsoleWindow::startSolverSilently()

--- a/libs/solverconsole/solverconsolewindow.cpp
+++ b/libs/solverconsole/solverconsolewindow.cpp
@@ -51,6 +51,7 @@ void SolverConsoleWindow::Impl::init()
 	m_console->setReadOnly(true);
 	m_console->setAutoFillBackground(true);
 	m_console->setWordWrapMode(QTextOption::WrapAnywhere);
+	m_console->setUndoRedoEnabled(false);
 	QFont font("Courier");
 	font.setStyleHint(QFont::Courier);
 	font.setPointSize(9);

--- a/libs/solverconsole/solverconsolewindowprojectdataitem.h
+++ b/libs/solverconsole/solverconsolewindowprojectdataitem.h
@@ -16,7 +16,7 @@ class SOLVERCONSOLEDLL_EXPORT SolverConsoleWindowProjectDataItem : public Projec
 	Q_OBJECT
 
 public:
-	const static int MAXLINES = 200;
+	const static int MAXLINES = 2000;
 	SolverConsoleWindowProjectDataItem(SolverConsoleWindow* w, ProjectDataItem* parent);
 	~SolverConsoleWindowProjectDataItem();
 


### PR DESCRIPTION
Hi Keisuke,

There was a bug that crashed iRIC if you set Options->Preferences... when no project was loaded. I wanted to see if I could make it with an unlimited number of lines and determined (probably like you) that loading the [QPlainTextEdit](https://doc.qt.io/qt-5/qplaintextedit.html) control gets really slow when the number of lines is very large.  So I merged mine into yours and set the default to 2000 lines. Hopefully you're OK with this. I included a python script to create files of different lengths [write.zip](https://github.com/kskinoue0612/prepost-gui/files/4435367/write.zip) if you want to test.


Thanks
Scott
