### PR TITLE
misc fixes to issue-852 branch

### DIFF
--- a/libs/guibase/coordinates/private/coordinateseditdialogdelegate.cpp
+++ b/libs/guibase/coordinates/private/coordinateseditdialogdelegate.cpp
@@ -11,7 +11,7 @@ CoordinatesEditDialogDelegate::CoordinatesEditDialogDelegate(QObject* parent) :
 void CoordinatesEditDialogDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
 	double val = index.model()->data(index, Qt::DisplayRole).toDouble();
-	CoordinateEditWidget widget;
+	static CoordinateEditWidget widget;
 	widget.setValue(val);
 
 	QPixmap pixmap(option.rect.size());

--- a/libs/guibase/widget/coordinateeditwidget.cpp
+++ b/libs/guibase/widget/coordinateeditwidget.cpp
@@ -1,14 +1,17 @@
 #include "coordinateeditwidget.h"
 #include "misc/stringtool.h"
 #include <cmath>
+#include <limits>
 #include <QDoubleValidator>
 #include <QMessageBox>
 
 CoordinateEditWidget::CoordinateEditWidget(QWidget* parent) :
 	QLineEdit(parent),
-	m_doubleValue {0},
+	m_doubleValue {std::numeric_limits<double>::signaling_NaN()},
 	m_eventCheck {true}
 {
+	Q_ASSERT(std::numeric_limits<double>::has_signaling_NaN);
+	Q_ASSERT(m_doubleValue != m_doubleValue);
 	setValidator(new QDoubleValidator(this));
 	connect(this, SIGNAL(textChanged(QString)), this, SLOT(handleTextChange()));
 }

--- a/libs/pre/datamodel/preprocessorgridattributemappingsettingtopdataitem.cpp
+++ b/libs/pre/datamodel/preprocessorgridattributemappingsettingtopdataitem.cpp
@@ -222,7 +222,7 @@ void PreProcessorGridAttributeMappingSettingTopDataItem::customMapping(bool nome
 		}
 		GridAttributeContainer* cont = grid->gridAttribute(item->condition()->name());
 		if (cont->isCustomModified()) {
-			int ret = QMessageBox::warning(preProcessorWindow(), tr("Warning"), tr("The grid attribute \"%1\" is edited by hand. When you execute mapping, all modifications you made will be discarted. Do you really want to execute mapping?").arg(item->condition()->caption()), QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+			int ret = QMessageBox::warning(preProcessorWindow(), tr("Warning"), tr("The grid attribute \"%1\" is edited by hand. When you execute mapping, all modifications you made will be discarded. Do you really want to execute mapping?").arg(item->condition()->caption()), QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
 			if (ret == QMessageBox::Yes) {
 				count = count + item->mappingCount();
 			} else {
@@ -240,7 +240,7 @@ void PreProcessorGridAttributeMappingSettingTopDataItem::customMapping(bool nome
 			continue;
 		}
 		if (item->bcDataItem()->isCustomModified()) {
-			int ret = QMessageBox::warning(preProcessorWindow(), tr("Warning"), tr("The boundary condition \"%1\" is edited by hand. When you execute mapping, all modifications you made will be discarted. Do you really want to execute mapping?").arg(item->bcDataItem()->standardItem()->text()), QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+			int ret = QMessageBox::warning(preProcessorWindow(), tr("Warning"), tr("The boundary condition \"%1\" is edited by hand. When you execute mapping, all modifications you made will be discarded. Do you really want to execute mapping?").arg(item->bcDataItem()->standardItem()->text()), QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
 			if (ret == QMessageBox::Yes) {
 				count = count + 1;
 			} else {
@@ -295,7 +295,7 @@ void PreProcessorGridAttributeMappingSettingTopDataItem::customMapping(const std
 	Grid* grid = conditiondi->gridDataItem()->grid();
 	if (grid == nullptr) {return;}
 	if (grid->gridAttribute(attName)->isCustomModified() && ! iricMainWindow()->cuiMode()) {
-		int ret = QMessageBox::warning(preProcessorWindow(), tr("Warning"), tr("The grid attribute \"%1\" is edited by hand. When you execute mapping, all modifications you made will be discarted. Do you really want to execute mapping?").arg(grid->gridAttribute(attName)->gridAttribute()->caption()), QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+		int ret = QMessageBox::warning(preProcessorWindow(), tr("Warning"), tr("The grid attribute \"%1\" is edited by hand. When you execute mapping, all modifications you made will be discarded. Do you really want to execute mapping?").arg(grid->gridAttribute(attName)->gridAttribute()->caption()), QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
 		if (ret == QMessageBox::No) {return;}
 	}
 	for (auto it = m_childItems.begin(); it != m_childItems.end(); ++it) {


### PR DESCRIPTION
Hi Keisuke,

I made the following changes:
1.  Fix display of 0 (zero) in Edit Coordinates dialog (2974cda) :
![image](https://user-images.githubusercontent.com/7538707/104238890-df760700-5416-11eb-8dc7-585c3623dd57.png)
![image](https://user-images.githubusercontent.com/7538707/104239009-0a605b00-5417-11eb-838b-9a3a8354dd4d.png)
2. Fix typo in warning message box (a29a2fa)
3. Reduced calls to CoordinateEditWidget ctor in paint function by making it static (43850c2)

Everything else seems to be good.

Thanks,
Scott


